### PR TITLE
Refatora logger_config para centralizar mensagens no logging

### DIFF
--- a/logger_config.py
+++ b/logger_config.py
@@ -7,6 +7,28 @@ import types
 _BASE_DIR = Path(__file__).resolve().parent
 _LOG_DIR = _BASE_DIR / "log"
 _LOG_FILE = _LOG_DIR / "fast.log"
+_LOGGER = logging.getLogger(__name__)
+
+
+def _is_valid_log_level(value):
+    """Valida se o valor pode ser convertido para um nível de log suportado."""
+    try:
+        level_num = int(value)
+        return level_num in (
+            logging.CRITICAL,
+            logging.ERROR,
+            logging.WARNING,
+            logging.INFO,
+            logging.DEBUG,
+            logging.NOTSET,
+        )
+    except (ValueError, TypeError):
+        pass
+
+    level_name = str(value).strip().upper()
+    if level_name == "WARN":
+        level_name = "WARNING"
+    return hasattr(logging, level_name)
 
 
 def log_function_call(func):
@@ -56,14 +78,7 @@ def get_log_level():
     # Tenta converter para inteiro
     try:
         level_num = int(env_level)
-        if level_num in (
-            logging.CRITICAL,
-            logging.ERROR,
-            logging.WARNING,
-            logging.INFO,
-            logging.DEBUG,
-            logging.NOTSET,
-        ):
+        if _is_valid_log_level(level_num):
             return level_num
     except (ValueError, TypeError):
         pass
@@ -75,7 +90,11 @@ def get_log_level():
     if hasattr(logging, env_level_name):
         return getattr(logging, env_level_name)
 
-    print(f"[DEBUG] LFASTLOGLEVEL={env_level}, log_level={env_level_name}")
+    _LOGGER.debug(
+        "LFASTLOGLEVEL inválido '%s'. Usando fallback INFO (normalizado: %s)",
+        env_level,
+        env_level_name,
+    )
     return logging.INFO
 
 
@@ -139,11 +158,8 @@ def setup_logging():
     # Obtém o nível de log da variável de ambiente
     log_level = get_log_level()
     level_name = logging.getLevelName(log_level)
-
-    # Loga o valor lido da variável de ambiente para depuração
-    print(
-        f"[LOG VAR] LFASTLOGLEVEL={os.getenv('LFASTLOGLEVEL')}, log_level={log_level} ({level_name})"
-    )
+    env_level = os.getenv("LFASTLOGLEVEL")
+    invalid_env_level = not _is_valid_log_level(env_level)
 
     # Remove handlers antigos para evitar logs duplicados
     root_logger = logging.getLogger()
@@ -170,9 +186,22 @@ def setup_logging():
     root_logger.addHandler(file_handler)
     root_logger.addHandler(console_handler)
 
-    logging.info(
-        f"Logging inicializado com o nível: {level_name} (from LFASTLOGLEVEL={os.getenv('LFASTLOGLEVEL')})"
+    _LOGGER.info(
+        "Logging inicializado com o nível: %s (from LFASTLOGLEVEL=%s)",
+        level_name,
+        env_level,
     )
+    _LOGGER.debug(
+        "[LOG VAR] LFASTLOGLEVEL=%s, log_level=%s (%s)",
+        env_level,
+        log_level,
+        level_name,
+    )
+    if invalid_env_level:
+        _LOGGER.debug(
+            "LFASTLOGLEVEL inválido '%s'. Fallback INFO aplicado durante bootstrap.",
+            env_level,
+        )
 
 
 def set_log_level(level):


### PR DESCRIPTION
### Motivation

- Remover saídas diretas para `stdout` via `print(...)` durante o bootstrap de logging e centralizar todas as mensagens no sistema de `logging` do módulo.
- Garantir que mensagens de inicialização sejam emitidas apenas depois que handlers do logger estejam configurados, mantendo o comportamento de fallback quando `LFASTLOGLEVEL` for inválida.
- Preservar a API pública existente (`setup_logging`, `set_log_level`, `get_log_level`, etc.) sem alterar assinaturas.

### Description

- Removeu `print(...)` de `get_log_level()` e `setup_logging()` e passou a usar um logger de módulo `_LOGGER = logging.getLogger(__name__)` para mensagens de debug/info.
- Adicionou a função interna `_is_valid_log_level(value)` para validar níveis (nomes e números) e reutilizar a lógica de validação sem alterar a semântica do fallback.
- Em `setup_logging()` as mensagens de bootstrap (`info`/`debug`) são emitidas via `_LOGGER` depois que os handlers (arquivo e console) são adicionados ao `root` logger.
- Mantido o comportamento de fallback: `get_log_level()` retorna `logging.INFO` quando `LFASTLOGLEVEL` é inválida, e agora há mensagens `debug` que explicam o fallback.

### Testing

- Executado `python -m py_compile logger_config.py` e a compilação do módulo passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f6e436a888322a70b71767cfbd824)

## Summary by Sourcery

Centralize logger configuration bootstrap messages into the standard logging system instead of printing directly to stdout.

Enhancements:
- Introduce a reusable internal validator for log level values to keep fallback semantics consistent while simplifying validation logic.
- Route environment-based log level diagnostics and bootstrap messages through a module logger emitted after handlers are configured, replacing prior print-based output.