### PR TITLE
Padroniza leitura/gravação de tema em `theme_name`

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -132,7 +132,7 @@ class TemplateApp(ctk.CTk):
             self.config = {}
 
         # Inicializar o ThemeManager primeiro (ele será usado por outras janelas)
-        self.theme_name = self.config.get("theme", "Linx")
+        self.theme_name = self.config.get("theme_name", "green")
         self.appearance_mode = self.config.get("appearance_mode", "dark")
 
         # Criar e configurar o ThemeManager global

--- a/settings_manager.py
+++ b/settings_manager.py
@@ -5,6 +5,9 @@ from logger_config import set_log_level
 
 logger = logging.getLogger(__name__)
 
+THEME_KEY = "theme_name"
+LEGACY_THEME_KEY = "theme"
+
 
 DEFAULT_CONFIG = {
     "geometry": None,
@@ -31,6 +34,10 @@ def load_config(path="config.json"):
             # Merge defaults
             merged = DEFAULT_CONFIG.copy()
             merged.update(cfg)
+            # Migração: respeita a chave canônica e usa legado apenas como fallback.
+            if THEME_KEY not in cfg and LEGACY_THEME_KEY in cfg:
+                merged[THEME_KEY] = cfg[LEGACY_THEME_KEY]
+            merged.pop(LEGACY_THEME_KEY, None)
             return merged
         except Exception as e:
             logger.error(f"Erro ao carregar {path}: {e}")
@@ -40,8 +47,10 @@ def load_config(path="config.json"):
 
 def save_config(config, path="config.json"):
     try:
+        serialized_config = config.copy()
+        serialized_config.pop(LEGACY_THEME_KEY, None)
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(config, f, indent=4, ensure_ascii=False)
+            json.dump(serialized_config, f, indent=4, ensure_ascii=False)
         return True
     except Exception as e:
         logger.error(f"Erro ao salvar config {path}: {e}")

--- a/settings_window.py
+++ b/settings_window.py
@@ -215,7 +215,7 @@ class SettingsWindow(ctk.CTkToplevel):
         )
         ctk_themes = ["green", "blue", "dark-blue"]
         theme_files = ctk_themes + custom_themes
-        self.theme_var = ctk.StringVar(value=self.config.get("theme", "Linx"))
+        self.theme_var = ctk.StringVar(value=self.config.get("theme_name", "green"))
         theme_combo = ctk.CTkComboBox(
             theme_select_frame,
             values=theme_files,
@@ -411,7 +411,8 @@ class SettingsWindow(ctk.CTkToplevel):
 
     def _on_theme_change(self, value):
         """Handle theme changes in real-time"""
-        self.config["theme"] = value
+        self.config["theme_name"] = value
+        self.config.pop("theme", None)
         try:
             self.theme_manager.set_theme(value)
             save_config(self.config, self.config_path)
@@ -607,14 +608,18 @@ class SettingsWindow(ctk.CTkToplevel):
             import json
 
             obj = json.loads(cfg)
+            if "theme_name" not in obj and "theme" in obj:
+                obj["theme_name"] = obj["theme"]
+            obj.pop("theme", None)
             # Merge and save
             self.config.update(obj)
+            self.config.pop("theme", None)
             save_config(self.config, self.config_path)
             messagebox.showinfo("Importado", "Configuração importada com sucesso.")
             # Apply some settings immediately
-            if "theme" in obj:
+            if "theme_name" in obj:
                 try:
-                    self.theme_manager.set_theme(obj["theme"])
+                    self.theme_manager.set_theme(obj["theme_name"])
                 except Exception:
                     pass
             if "appearance_mode" in obj:
@@ -634,8 +639,10 @@ class SettingsWindow(ctk.CTkToplevel):
         try:
             import json
 
+            export_config = self.config.copy()
+            export_config.pop("theme", None)
             with open(path, "w", encoding="utf-8") as f:
-                json.dump(self.config, f, indent=4, ensure_ascii=False)
+                json.dump(export_config, f, indent=4, ensure_ascii=False)
             messagebox.showinfo("Exportado", f"Config exportada para: {path}")
         except Exception as e:
             messagebox.showerror("Erro", f"Erro ao exportar configuração: {e}")


### PR DESCRIPTION
### Motivation
- Unificar o identificador de tema para evitar leituras/escritas divergentes entre telas e persistência, usando `theme_name` como chave canônica.
- Preservar compatibilidade com configurações antigas que ainda usam a chave legada `theme` sem reintroduzi-la no arquivo salvo.

### Description
- Define constantes `THEME_KEY` e `LEGACY_THEME_KEY` em `settings_manager.py` e adiciona migração em `load_config` que copia `theme` para `theme_name` somente quando a canônica estiver ausente, removendo a chave legada da configuração em memória.
- Faz com que `save_config` remova a chave legada antes de serializar para evitar recriação de `theme` no arquivo salvo.
- Atualiza `main_window.py` para ler `self.config.get("theme_name", "green")` na inicialização do `ThemeManager`.
- Atualiza `settings_window.py` para usar `theme_name` na UI (`theme_var`), fazer `_on_theme_change` gravando `theme_name` e removendo `theme`, migrar `theme` para `theme_name` no `_import_config`, e não incluir `theme` no `_export_config`.

### Testing
- Validated syntax by running `python -m py_compile settings_manager.py main_window.py settings_window.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f6e48660c83228d6af4173254dff7)

## Summary by Sourcery

Standardize theme configuration to use a canonical `theme_name` key across loading, saving, and UI, while transparently migrating from the legacy `theme` key and excluding it from persisted/exported configs.

Enhancements:
- Add canonical and legacy theme key constants and migrate `theme` to `theme_name` during config load without persisting the legacy key.
- Ensure config save and export paths strip the legacy `theme` key so only `theme_name` is written to disk.
- Update main and settings windows to read and write the theme via `theme_name`, including imports/exports and live theme changes.